### PR TITLE
Update models_out.py

### DIFF
--- a/models/models_out.py
+++ b/models/models_out.py
@@ -6,3 +6,26 @@ class UserOut(BaseModel):
     username: str = None
     email: str = None
     registration_date: str = None
+    
+class TimelineItemOut(BaseModel):
+    date: str
+    title: str
+    author: str
+    doi: str
+    score: float
+    
+#文献时间线，含多个文献项及其统计信息。
+class LiteratureTimelineOut(BaseModel):
+    total_count: int #时间线中包含的文献总数。
+    date_range: dict #时间线的时间范围，可能是一个字典，包含开始日期和结束日期。
+    timeline: list[TimelineItemOut] #一个TimelineItemOut对象的列表，表示时间线上的所有文献项。
+    yearly_distribution: dict #按年份分布的文献数量，键是年份，值是该年份的文献数量。
+    monthly_distribution: dict #按月份分布的文献数量，键是月份，值是该月份的文献数量。
+
+#文献时间统计信息
+class LiteratureTimeStatsOut(BaseModel):
+    total_literatures: int
+    date_range: dict
+    yearly_stats: dict
+    publication_trends: dict
+    quality_metrics: dict


### PR DESCRIPTION
1. TimelineItemOut一个时间线上的单个文献项 date：文献的发布日期
title：文献的标题
author：文献的作者
doi：文献的数字对象标识符（DOI）
score：用于表示文献的重要性或相关性
2. LiteratureTimelineOut文献时间线 total_count：时间线中包含的文献总数。
date_range：时间线的时间范围，包含开始日期和结束日期。
timeline：一个TimelineItemOut对象的列表，表示时间线上的所有文献项。
yearly_distribution：按年份分布的文献数量，键是年份，值是该年份的文献数量。
monthly_distribution：按月份分布的文献数量，键是月份，值是该月份的文献数量。
3. LiteratureTimeStatsOut文献时间统计信息 total_literatures：总文献数
date_range：文献的时间范围
yearly_stats：按年份统计的文献信息（文献数量、引用次数）
publication_trends：文献的出版趋势，包含每年或每月的文献数量变化趋势
quality_metrics：文献的质量指标，包含文献的评分、引用次数等质量相关的统计信息。